### PR TITLE
Add stable version for sentry/sentry dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
-    - 8.0snapshot
+    - 8.0
 
 env:
     matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 All notable changes to `laravel-notify` will be documented in this file.
 
-### Unreleased
+### 4.0.1
+- Add stable version for [`sentry/sentry`](https://github.com/getsentry/sentry-php) dependency
+
+### 4.0.0
 - Updated for Laravel 7 and 8
 - Add support for PHP 7.3, 7.4, 8.0
 - Removed support for Laravel 5.5, 5.6, 5.7, 5.8
 - Removed support for PHP 7.0, 7.1
-- Removed deprecated RavenHandler handler, use sentry/sentry 3.x and their Sentry\Monolog\Handler instead
+- Removed deprecated RavenHandler handler, use sentry/sentry 3.1.x and their Sentry\Monolog\Handler instead
 - Removed deprecated HipChat handler, migrate to Slack and use SlackWebhookHandler or SlackHandler instead
 
 ### 3.0.0

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "tylercd100/monolog-sms":"^2.0"
     },
     "require-dev": {
-        "sentry/sentry": "dev-php8-support",
+        "sentry/sentry": "^3.1.1",
         "symfony/options-resolver": "^5.1",
         "http-interop/http-factory-guzzle": "^1.0.0",
         "php-http/guzzle7-adapter": "^0.2.0",
@@ -45,7 +45,7 @@
         "orchestra/testbench": "^4.0|^5.0|^6.0"
     },
     "suggest": {
-        "sentry/sentry": "Required to use the Sentry driver (~3.0)."
+        "sentry/sentry": "Required to use the Sentry driver (^3.1.1)."
     },
     "extra": {
         "providers": [


### PR DESCRIPTION
To support PHP 8.0, see: https://github.com/getsentry/sentry-php/releases/tag/3.1.1

- Update Changelog
- Update Travis CI to use PHP `8.0` instead of `8.0snapshot`